### PR TITLE
Fixed Index Reference in VAE Model for Vocabulary Size of 30

### DIFF
--- a/genmol/vae/data.py
+++ b/genmol/vae/data.py
@@ -27,7 +27,7 @@ def char2id(char):
 
 def id2char(id):
     if id not in i2c:
-        return i2c[32]
+        return i2c[29]
     else:
         return i2c[id]
 


### PR DESCRIPTION
Here, i2c[32] was being used, but the vocabulary size (all_sys) is only 30. This caused an Error since the index 32 does not exist in the i2c mapping. So, updated the reference from i2c[32] to i2c[29] to match the actual size of the vocabulary.
![Screenshot (22)](https://github.com/user-attachments/assets/02c23fb8-0deb-4010-aa78-6c56c7f8d8c2)
